### PR TITLE
revamp amqp10 queue creation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -79,7 +79,8 @@
       "env": {
         "NODE_ENV": "localhost",
         "CRAWLER_MODE": "StandardWithoutEvents",
-        "CRAWLER_OPTIONS_PROVIDER": "redis"
+        "CRAWLER_OPTIONS_PROVIDER": "redis",
+        "DEBUG.off": "amqp10:client,amqp10:link:receiver"
       },
       "console": "internalConsole",
       "sourceMaps": false,

--- a/lib/amqp10Queue.js
+++ b/lib/amqp10Queue.js
@@ -10,9 +10,29 @@ const AmqpClient = amqp10.Client;
 const AmqpPolicy = amqp10.Policy;
 const AmqpConstants = amqp10.Constants;
 
-class Amqp10Queue {
-  constructor(url, name, formatter, options) {
+class QueueFactory {
+  constructor(url) {
     this.url = url;
+    this.client = null;
+  }
+
+  createQueue(name, formatter, options) {
+    return new Amqp10Queue(this._getClient(), name, formatter, options);
+  }
+
+  _getClient() {
+    if (this.client) {
+      return this.client;
+    }
+    const actualClient = new AmqpClient(AmqpPolicy.ServiceBusQueue);
+    this.client = actualClient.connect(this.url).then(() => { return actualClient; });
+    return this.client;
+  }
+}
+
+class Amqp10Queue {
+  constructor(client, name, formatter, options) {
+    this.client = client;
     this.name = name;
     this.queueName = `${options.queueName}-${name}`;
     this.messageFormatter = formatter;
@@ -21,48 +41,49 @@ class Amqp10Queue {
     this.currentAmqpCredit = options.credit || 10;
     this.options._config.on('changed', this._reconfigure.bind(this));
 
-    this.client = null;
     this.receiver = null;
     this.sender = null;
     this.messages = [];
   }
 
   subscribe() {
-    if (this.client && this.receiver && this.sender) {
+    if (this.receiver && this.sender) {
       return Q();
     }
-    let policy = AmqpPolicy.Utils.RenewOnSettle(this.currentAmqpCredit, AmqpConstants.receiverSettleMode.settleOnDisposition);
-    const size = (this.options.messageSize || 128) * 1024;
-    policy = AmqpPolicy.merge({
-      senderLink: { attach: { maxMessageSize: size }, reconnect: { forever: true } },
-      receiverLink: { attach: { maxMessageSize: size }, reconnect: { forever: true } }
-    }, policy);
-    this.client = new AmqpClient(AmqpPolicy.ServiceBusQueue, policy);
-    return this.client.connect(this.url).then(() => {
+    const receive = !!this.messageFormatter;
+    return this.client.then(client => {
+      const size = (this.options.messageSize || 200) * 1024;
+      const basePolicy = {
+        senderLink: { attach: { maxMessageSize: size } },
+        receiverLink: { attach: { maxMessageSize: size } }
+      };
+      const receivePolicy = AmqpPolicy.Utils.RenewOnSettle(this.currentAmqpCredit || 10, 50, basePolicy).receiverLink;
       return Q.spread([
-        this.client.createReceiver(this.queueName),
-        this.client.createSender(this.queueName)
+        receive ? client.createReceiver(this.queueName, receivePolicy) : Q(null),
+        client.createSender(this.queueName, basePolicy.senderLink)
       ], (receiver, sender) => {
         this.logger.info(`Connecting to ${this.queueName}`);
-        this.receiver = receiver;
         this.sender = sender;
-        receiver.on('message', message => {
-          this.messages.push(message);
-        });
-        receiver.on('errorReceived', err => {
-          this._logReceiverSenderError(err, 'receiver');
-        });
         sender.on('errorReceived', err => {
           this._logReceiverSenderError(err, 'sender');
-        });
-        receiver.on('detached', () => {
-          this.logger.info(`Receiver detached from ${this.getName()}`);
         });
         sender.on('detached', () => {
           this.logger.info(`Sender detached from ${this.getName()}`);
         });
+        if (receiver) {
+          this.receiver = receiver;
+          receiver.on('message', message => {
+            this.messages.push(message);
+          });
+          receiver.on('errorReceived', err => {
+            this._logReceiverSenderError(err, 'receiver');
+          });
+          receiver.on('detached', () => {
+            this.logger.info(`Receiver detached from ${this.getName()}`);
+          });
+        }
         process.once('SIGINT', () => {
-          this.client.disconnect();
+          client.disconnect();
         });
         return Q();
       });
@@ -72,11 +93,13 @@ class Amqp10Queue {
   }
 
   unsubscribe() {
-    this.logger.info(`Disconnecting from ${this.queueName}`);
-    if (this.client) {
-      this.client.disconnect();
+    this.logger.info(`Detaching from ${this.queueName}`);
+    if (this.sender) {
+      this.sender.detach({ closed: true });
     }
-    this.client = null;
+    if (this.receiver) {
+      this.receiver.detach({ closed: true });
+    }
     this.receiver = null;
     this.sender = null;
     return Q();
@@ -210,4 +233,4 @@ class Amqp10Queue {
   }
 }
 
-module.exports = Amqp10Queue;
+module.exports = QueueFactory;

--- a/lib/ospoCrawler.js
+++ b/lib/ospoCrawler.js
@@ -527,13 +527,14 @@ class OspoCrawler {
 
   static createAmqp10Queues(options) {
     const url = config.get('CRAWLER_AMQP10_URL');
+    const factory = new Amqp10Queue(url);
     const env = process.env.NODE_ENV;
     const tracker = OspoCrawler.createRequestTracker(`${env}:AMQP10:${options.queueName}`, options);
-    const immediate = OspoCrawler.createAmqp10Queue(url, 'immediate', tracker, options);
-    const soon = OspoCrawler.createAmqp10Queue(url, 'soon', tracker, options);
-    const normal = OspoCrawler.createAmqp10Queue(url, 'normal', tracker, options);
-    const later = OspoCrawler.createAmqp10Queue(url, 'later', tracker, options);
-    const deadletter = OspoCrawler.createAmqp10Queue(url, 'deadletter', tracker, options);
+    const immediate = OspoCrawler.createAmqp10Queue(factory, 'immediate', tracker, options);
+    const soon = OspoCrawler.createAmqp10Queue(factory, 'soon', tracker, options);
+    const normal = OspoCrawler.createAmqp10Queue(factory, 'normal', tracker, options);
+    const later = OspoCrawler.createAmqp10Queue(factory, 'later', tracker, options);
+    const deadletter = OspoCrawler.createAmqp10Queue(factory, 'deadletter', tracker, options, false);
     const queues = OspoCrawler.addEventQueue([immediate, soon, normal, later], options);
     return new QueueSet(queues, deadletter, options);
   }
@@ -560,13 +561,13 @@ class OspoCrawler {
     return new AttenuatedQueue(new TrackedQueue(queue, tracker, options), options);
   }
 
-  static createAmqp10Queue(url, name, tracker, options) {
-    const formatter = message => {
+  static createAmqp10Queue(factory, name, tracker, options, receive = true) {
+    const formatter = !receive ? null : message => {
       // make sure the message/request object is copied to enable deferral scenarios (i.e., the request is modified
       // and then put back on the in-memory queue)
       return Request.adopt(Object.assign({}, message));
     };
-    const queue = new Amqp10Queue(url, name, formatter, options);
+    const queue = factory.createQueue(name, formatter, options);
     const trackedQueue = new TrackedQueue(queue, tracker, options);
     let innerQueue = trackedQueue;
     if (options.pushRateLimit) {


### PR DESCRIPTION
update the way we create amqp10 queues as follows

* use only one ampq client to manage all the queues in one process.  While the team says multiple clients should work, they also say that they all use one client
* refine the policy used.  In particular, update the receive _threshold_.  
* allow send-only queues to be created.  This is used for deadletter to prevent the crawler from holding onto the deadletter messages both locking them and ageing them out.

Would be great to have both @geneh and @willbar take a look.