### PR TITLE
enable deadletter reading in amqp10

### DIFF
--- a/lib/amqp10Queue.js
+++ b/lib/amqp10Queue.js
@@ -19,6 +19,7 @@ class Amqp10Queue {
     this.manager = manager;
     this.options = options;
     this.logger = options.logger;
+    this.mode = { receive: 'receive', send: 'send' };
     this.currentAmqpCredit = options.credit || 10;
     this.options._config.on('changed', this._reconfigure.bind(this));
 
@@ -33,10 +34,8 @@ class Amqp10Queue {
       this._silly('subscribe: exit (no receiver or sender)');
       return Q();
     }
-    // no formatter implies you don't want to receive
-    const receive = !!this.messageFormatter;
-    // bit of a hack but if the queue name has a / then it is likely a topic so don't hook up a sender
-    const send = !this.queueName.includes('/');
+    const receive = this.mode.receive === 'receive';
+    const send = this.mode.send === 'send';
     return this.client.then(client => {
       const queuePromise = this.manager ? this.manager.createQueue(this.queueName) : Q();
       queuePromise.then(() => {
@@ -108,6 +107,71 @@ class Amqp10Queue {
     this.sender = null;
     this.messages = [];
     this._silly('unsubscribe: exit');
+    return Q();
+  }
+
+  popMany(count, remove) {
+    const connect = this.mode.receive === 'onDemand';
+    return (connect ? this._subscribeReceive(count) : Q()).then(() => {
+      const result = [];
+      for (let i = 0; i < count; i++) {
+        result.push(this.pop());
+      }
+      return Q.all(result).then(requests => {
+        const filtered = requests.filter(request => request);
+        return Q.all(filtered.map(request => remove ? this.done(request) : this.abandon(request))).then(() => {
+          if (connect) this._unsubscribeReceive();
+          return filtered;
+        });
+      });
+    });
+  }
+
+  // TODO merge the two sets of subscribe and unsubscribe methods
+  _subscribeReceive(count = 0) {
+    // return if mode indicates that we should already be connected for receive then do nothing
+    if (this.mode.receive !== 'onDemand') {
+      return Q();
+    }
+
+    this.logger.info(`Attaching receiver for ${this.queueName}`);
+    const size = (this.options.messageSize || 200) * 1024;
+    const basePolicy = {
+      receiverLink: { attach: { maxMessageSize: size } }
+    };
+    const receivePolicy = AmqpPolicy.Utils.RenewOnSettle(count || this.currentAmqpCredit || 10, 1, basePolicy).receiverLink;
+    return this.client.then(client => {
+      client.createReceiver(this.queueName, receivePolicy).then(receiver => {
+        this.receiver = receiver;
+        receiver.on('message', message => {
+          this._silly('receiver: message received');
+          this.messages.push(message);
+        });
+        receiver.on('errorReceived', err => {
+          this._logReceiverSenderError(err, 'receiver');
+        });
+        receiver.on('attached', () => {
+          this.logger.info(`Receiver attached to ${this.getName()}`);
+        });
+        receiver.on('detached', () => {
+          this.logger.info(`Receiver detached from ${this.getName()}`);
+        });
+        return Q();
+      });
+    });
+  }
+
+  _unsubscribeReceive() {
+    // return if mode indicates that we should already be connected for receive then do nothing
+    if (this.mode.receive !== 'onDemand') {
+      return Q();
+    }
+    if (this.receiver) {
+      this._silly('unsubscribe: detaching receiver');
+      this.receiver.detach({ closed: true });
+    }
+    this.receiver = null;
+    this.messages = [];
     return Q();
   }
 

--- a/lib/amqpQueue.js
+++ b/lib/amqpQueue.js
@@ -82,6 +82,17 @@ class AmqpQueue {
     })));
   }
 
+  popMany(count, remove) {
+    const result = [];
+    for (let i = 0; i < count; i++) {
+      result.push(this.pop());
+    }
+    return Q.all(result).then(requests => {
+      const filtered = requests.filter(request => request);
+      return Q.all(filtered.map(request => remove ? this.done(request) : this.abandon(request))).thenResolve(filtered);
+    });
+  }
+
   pop() {
     const self = this;
     const message = this.pending.shift();

--- a/lib/inmemorycrawlqueue.js
+++ b/lib/inmemorycrawlqueue.js
@@ -29,6 +29,17 @@ class InMemoryCrawlQueue {
     return Q(null);
   }
 
+  popMany(count, remove) {
+    const result = [];
+    for (let i = 0; i < count; i++) {
+      result.push(this.pop());
+    }
+    return Q.all(result).then(requests => {
+      requests.map(request => remove ? this.done(request) : this.abandon(request));
+      return requests;
+    });
+  }
+
   pop() {
     const result = this.queue.shift();
     if (!result) {

--- a/lib/nestedQueue.js
+++ b/lib/nestedQueue.js
@@ -14,6 +14,10 @@ class NestedQueue {
     return this.queue.pop();
   }
 
+  popMany(count, remove) {
+    return this.queue.popMany(count, remove);
+  }
+
   done(request) {
     return this.queue.done(request);
   }

--- a/lib/ospoCrawler.js
+++ b/lib/ospoCrawler.js
@@ -554,7 +554,7 @@ class OspoCrawler {
     const soon = OspoCrawler.createAmqp10Queue(manager, 'soon', tracker, options);
     const normal = OspoCrawler.createAmqp10Queue(manager, 'normal', tracker, options);
     const later = OspoCrawler.createAmqp10Queue(manager, 'later', tracker, options);
-    const deadletter = OspoCrawler.createAmqp10Queue(manager, 'deadletter', tracker, options, false);
+    const deadletter = OspoCrawler.createAmqp10Queue(manager, 'deadletter', tracker, options, { receive: 'onDemand', send: 'send' });
     const queues = OspoCrawler.addEventQueue([immediate, soon, normal, later], options);
     return new QueueSet(queues, deadletter, options);
   }
@@ -581,15 +581,17 @@ class OspoCrawler {
     return new AttenuatedQueue(new TrackedQueue(queue, tracker, options), options);
   }
 
-  static createAmqp10Queue(manager, name, tracker, options, receive = true) {
-    const formatter = !receive ? null : message => {
+  static createAmqp10Queue(manager, name, tracker, options, mode = { receive: 'receive', send: 'send' }) {
+    const formatter = message => {
       // make sure the message/request object is copied to enable deferral scenarios (i.e., the request is modified
       // and then put back on the in-memory queue)
       return Request.adopt(Object.assign({}, message.body));
     };
-    const queue = manager.createQueueClient(name, formatter, options);
-    const trackedQueue = new TrackedQueue(queue, tracker, options);
-    let innerQueue = trackedQueue;
+    let queue = manager.createQueueClient(name, formatter, options);
+    queue.mode = mode;
+    if (tracker) {
+      queue = new TrackedQueue(queue, tracker, options);
+    }
     if (options.pushRateLimit) {
       const limiter = InMemoryRateLimiter.create({
         key: () => 'queue:' + name,
@@ -597,10 +599,9 @@ class OspoCrawler {
         limit: () => options.pushRateLimit || 300
       });
 
-      innerQueue = new RateLimitedPushQueue(trackedQueue, limiter, options);
+      queue = new RateLimitedPushQueue(queue, limiter, options);
     }
-    const attenuatedQueue = new AttenuatedQueue(innerQueue, options);
-    return attenuatedQueue;
+    return new AttenuatedQueue(queue, options);
   }
 
   static addEventQueue(queues, options) {
@@ -624,7 +625,9 @@ class OspoCrawler {
     const formatter = new EventFormatter(options);
     options._config.on('change', formatter.reconfigure.bind(formatter));
     const queueName = `${options.events.topic}/Subscriptions/${options.events.queueName}`;
-    return new Amqp10Queue(client, 'events', queueName, formatter.format.bind(formatter), null, options);
+    const result = new Amqp10Queue(client, 'events', queueName, formatter.format.bind(formatter), options);
+    result.mode = { receive: 'receive' };
+    return result;
   }
 
   static createQueuingMetrics(crawlerName, options) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "express": "^4.14.0",
     "express-init": "^1.1.0",
     "express-joi": "^0.3.1",
-    "ghcrawler": "^0.2.17",
+    "ghcrawler": "^0.2.18",
     "ghrequestor": "^0.1.6",
     "htmlencode": "0.0.4",
     "ip": "^1.1.4",


### PR DESCRIPTION
the Deadletter queue in amqp10 was setup to not receive messages as normally we never read from that queue.  since the change to base the Dashboard on Crawler service API, we actually do need, once in a while, to read from the deadletter queue.  This PR adds support for on demand receiving from an otherwise disconnected amqp 1.0 queue