### PR TITLE
switch deadletters from queue to store based

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -111,7 +111,7 @@
       "env": {
         "NODE_ENV": "localhost",
         "CRAWLER_MODE": "Standard",
-        "CRAWLER_EVENT_PROVIDER": "",
+        "CRAWLER_EVENT_PROVIDER": "none",
         "CRAWLER_OPTIONS_PROVIDER": "redis",
         "DEBUG.off": "amqp10:client,amqp10:link:receiver"
       },
@@ -196,7 +196,7 @@
       "name": "Attach to Process",
       "type": "node",
       "request": "attach",
-      "processId": "${command.PickProcess}",
+      "processId": "${command:PickProcess}",
       "port": 5858,
       "sourceMaps": false,
       "outFiles": []

--- a/app.js
+++ b/app.js
@@ -26,6 +26,7 @@ app.use('/status', require('./routes/status')(service));
 app.use('/config', require('./routes/config')(service));
 app.use('/requests', require('./routes/requests')(service));
 app.use('/queues', require('./routes/queues')(service));
+app.use('/deadletters', require('./routes/deadletters')(service));
 
 // to keep AlwaysOn flooding logs with errors
 app.get('/', function (request, response, next) {

--- a/lib/amqp10Queue.js
+++ b/lib/amqp10Queue.js
@@ -38,7 +38,7 @@ class Amqp10Queue {
     const send = this.mode.send === 'send';
     return this.client.then(client => {
       const queuePromise = this.manager ? this.manager.createQueue(this.queueName) : Q();
-      queuePromise.then(() => {
+      return queuePromise.then(() => {
         const size = (this.options.messageSize || 200) * 1024;
         const basePolicy = {
           senderLink: { attach: { maxMessageSize: size } },
@@ -107,71 +107,6 @@ class Amqp10Queue {
     this.sender = null;
     this.messages = [];
     this._silly('unsubscribe: exit');
-    return Q();
-  }
-
-  popMany(count, remove) {
-    const connect = this.mode.receive === 'onDemand';
-    return (connect ? this._subscribeReceive(count) : Q()).then(() => {
-      const result = [];
-      for (let i = 0; i < count; i++) {
-        result.push(this.pop());
-      }
-      return Q.all(result).then(requests => {
-        const filtered = requests.filter(request => request);
-        return Q.all(filtered.map(request => remove ? this.done(request) : this.abandon(request))).then(() => {
-          if (connect) this._unsubscribeReceive();
-          return filtered;
-        });
-      });
-    });
-  }
-
-  // TODO merge the two sets of subscribe and unsubscribe methods
-  _subscribeReceive(count = 0) {
-    // return if mode indicates that we should already be connected for receive then do nothing
-    if (this.mode.receive !== 'onDemand') {
-      return Q();
-    }
-
-    this.logger.info(`Attaching receiver for ${this.queueName}`);
-    const size = (this.options.messageSize || 200) * 1024;
-    const basePolicy = {
-      receiverLink: { attach: { maxMessageSize: size } }
-    };
-    const receivePolicy = AmqpPolicy.Utils.RenewOnSettle(count || this.currentAmqpCredit || 10, 1, basePolicy).receiverLink;
-    return this.client.then(client => {
-      client.createReceiver(this.queueName, receivePolicy).then(receiver => {
-        this.receiver = receiver;
-        receiver.on('message', message => {
-          this._silly('receiver: message received');
-          this.messages.push(message);
-        });
-        receiver.on('errorReceived', err => {
-          this._logReceiverSenderError(err, 'receiver');
-        });
-        receiver.on('attached', () => {
-          this.logger.info(`Receiver attached to ${this.getName()}`);
-        });
-        receiver.on('detached', () => {
-          this.logger.info(`Receiver detached from ${this.getName()}`);
-        });
-        return Q();
-      });
-    });
-  }
-
-  _unsubscribeReceive() {
-    // return if mode indicates that we should already be connected for receive then do nothing
-    if (this.mode.receive !== 'onDemand') {
-      return Q();
-    }
-    if (this.receiver) {
-      this._silly('unsubscribe: detaching receiver');
-      this.receiver.detach({ closed: true });
-    }
-    this.receiver = null;
-    this.messages = [];
     return Q();
   }
 

--- a/lib/amqpQueue.js
+++ b/lib/amqpQueue.js
@@ -82,17 +82,6 @@ class AmqpQueue {
     })));
   }
 
-  popMany(count, remove) {
-    const result = [];
-    for (let i = 0; i < count; i++) {
-      result.push(this.pop());
-    }
-    return Q.all(result).then(requests => {
-      const filtered = requests.filter(request => request);
-      return Q.all(filtered.map(request => remove ? this.done(request) : this.abandon(request))).thenResolve(filtered);
-    });
-  }
-
   pop() {
     const self = this;
     const message = this.pending.shift();

--- a/lib/inmemoryDocStore.js
+++ b/lib/inmemoryDocStore.js
@@ -48,19 +48,10 @@ class InmemoryDocStore {
     const result = [];
     for (let collection in collections) {
       for (let document in collection.for) {
-        const entry = Object.assign({}, document._metadata);
-        this._collapseExtraMetadata(document._metadata, entry);
-        result.push(entry);
+        result.push(document._metadata);
       }
     }
-  }
-
-  _collapseExtraMetadata(source, target) {
-    if (source.extra) {
-      Object.getOwnPropertyNames(source.extra).forEach(property => {
-        target[`extra_${property}`] = source.extra[property];
-      });
-    }
+    return result;
   }
 
   close() {

--- a/lib/inmemoryDocStore.js
+++ b/lib/inmemoryDocStore.js
@@ -44,6 +44,25 @@ class InmemoryDocStore {
     return Q(result);
   }
 
+  listDocuments(pattern) {
+    const result = [];
+    for (let collection in collections) {
+      for (let document in collection.for) {
+        const entry = Object.assign({}, document._metadata);
+        this._collapseExtraMetadata(document._metadata, entry);
+        result.push(entry);
+      }
+    }
+  }
+
+  _collapseExtraMetadata(source, target) {
+    if (source.extra) {
+      Object.getOwnPropertyNames(source.extra).forEach(property => {
+        target[`extra_${property}`] = source.extra[property];
+      });
+    }
+  }
+
   close() {
     content = {};
   }

--- a/lib/inmemorycrawlqueue.js
+++ b/lib/inmemorycrawlqueue.js
@@ -29,17 +29,6 @@ class InMemoryCrawlQueue {
     return Q(null);
   }
 
-  popMany(count, remove) {
-    const result = [];
-    for (let i = 0; i < count; i++) {
-      result.push(this.pop());
-    }
-    return Q.all(result).then(requests => {
-      requests.map(request => remove ? this.done(request) : this.abandon(request));
-      return requests;
-    });
-  }
-
   pop() {
     const result = this.queue.shift();
     if (!result) {

--- a/lib/mongodocstore.js
+++ b/lib/mongodocstore.js
@@ -59,6 +59,11 @@ class MongoDocStore {
     });
   }
 
+  listDocuments(pattern) {
+    // TODO implement
+    return Q([]);
+  }
+
   close() {
     this.db.close();
   }

--- a/lib/nestedQueue.js
+++ b/lib/nestedQueue.js
@@ -14,10 +14,6 @@ class NestedQueue {
     return this.queue.pop();
   }
 
-  popMany(count, remove) {
-    return this.queue.popMany(count, remove);
-  }
-
   done(request) {
     return this.queue.done(request);
   }

--- a/lib/ospoCrawler.js
+++ b/lib/ospoCrawler.js
@@ -182,7 +182,8 @@ class OspoCrawler {
 
   static _initialize() {
     return Q.try(this.queues.subscribe.bind(this.queues))
-      .then(this.store.connect.bind(this.store));
+      .then(this.store.connect.bind(this.store))
+      .then(this.deadletters.connect.bind(this.deadletters));
   }
 
   static createRefreshingOptions(crawlerName, subsystemNames, provider = 'redis') {

--- a/lib/ospoCrawler.js
+++ b/lib/ospoCrawler.js
@@ -48,7 +48,7 @@ const winston = require('winston');
 const AmqpClient = amqp10.Client;
 const AmqpPolicy = amqp10.Policy;
 
-let factoryLogger;
+let factoryLogger = null;
 let redisClient = null;
 
 class OspoCrawler {
@@ -117,9 +117,6 @@ class OspoCrawler {
   }
 
   static createService(name) {
-    if (!factoryLogger) {
-      factoryLogger = OspoCrawler.createLogger(true);
-    }
     factoryLogger.info('appInitStart');
     const crawlerName = config.get('CRAWLER_NAME') || 'crawler';
     const optionsProvider = config.get('CRAWLER_OPTIONS_PROVIDER') || 'memory';
@@ -154,6 +151,7 @@ class OspoCrawler {
     options.queuing.metricsStore = null;
     options.locker.provider = 'memory';
     options.storage.provider = 'memory';
+    return options;
   }
 
   static _decorateOptions(options) {
@@ -169,14 +167,15 @@ class OspoCrawler {
     });
   }
 
-  static createCrawler(options, { queues = null, store = null, locker = null, fetcher = null, processor = null } = {}) {
+  static createCrawler(options, { queues = null, store = null, deadletters = null, locker = null, fetcher = null, processor = null} = {}) {
     OspoCrawler._decorateOptions(options);
     queues = queues || OspoCrawler.createQueues(options.queuing);
     store = store || OspoCrawler.createStore(options.storage);
+    deadletters = deadletters || OspoCrawler.createDeadletterStore(options.storage);
     locker = locker || OspoCrawler.createLocker(options.locker);
     fetcher = fetcher || OspoCrawler.createGitHubFetcher(store, options.fetcher);
     processor = processor || new GitHubProcessor(store);
-    const result = new Crawler(queues, store, locker, fetcher, processor, options.crawler);
+    const result = new Crawler(queues, store, deadletters, locker, fetcher, processor, options.crawler);
     result.initialize = OspoCrawler._initialize.bind(result);
     return result;
   }
@@ -411,6 +410,23 @@ class OspoCrawler {
     return new AzureStorageDocStore(blobService, name, options);
   }
 
+  static createDeadletterStore(options) {
+    const provider = options.provider || 'azure';
+    factoryLogger.info(`Create deadletter store for provider ${options.provider}`);
+    switch (options.provider) {
+      case 'azure': {
+        return  OspoCrawler.createAzureStorageStore(options, config.get('CRAWLER_STORAGE_NAME') + '-deadletter');
+      }
+      case 'mongo': {
+        return OspoCrawler.createMongoStore(options);
+      }
+      case 'memory': {
+        return new InMemoryDocStore(true);
+      }
+      default: throw new Error(`Invalid store provider: ${provider}`);
+    }
+  }
+
   static createDeltaStore(inner, options) {
     if (!options.delta || !options.delta.provider) {
       return inner;
@@ -539,9 +555,8 @@ class OspoCrawler {
     const soon = OspoCrawler.createAmqpQueue(manager, 'soon', tracker, options);
     const normal = OspoCrawler.createAmqpQueue(manager, 'normal', tracker, options);
     const later = OspoCrawler.createAmqpQueue(manager, 'later', tracker, options);
-    const deadletter = OspoCrawler.createAmqpQueue(manager, 'deadletter', tracker, options);
     const queues = OspoCrawler.addEventQueue([immediate, soon, normal, later], options);
-    return new QueueSet(queues, deadletter, options);
+    return new QueueSet(queues, options);
   }
 
   static createAmqp10Queues(options) {
@@ -554,9 +569,8 @@ class OspoCrawler {
     const soon = OspoCrawler.createAmqp10Queue(manager, 'soon', tracker, options);
     const normal = OspoCrawler.createAmqp10Queue(manager, 'normal', tracker, options);
     const later = OspoCrawler.createAmqp10Queue(manager, 'later', tracker, options);
-    const deadletter = OspoCrawler.createAmqp10Queue(manager, 'deadletter', tracker, options, { receive: 'onDemand', send: 'send' });
     const queues = OspoCrawler.addEventQueue([immediate, soon, normal, later], options);
-    return new QueueSet(queues, deadletter, options);
+    return new QueueSet(queues, options);
   }
 
   static createMemoryQueues(options) {
@@ -564,9 +578,8 @@ class OspoCrawler {
     const soon = OspoCrawler.createMemoryQueue('soon', options);
     const normal = OspoCrawler.createMemoryQueue('normal', options);
     const later = OspoCrawler.createMemoryQueue('later', options);
-    const deadletter = OspoCrawler.createMemoryQueue('deadletter', options);
     const queues = OspoCrawler.addEventQueue([immediate, soon, normal, later], options);
-    return new QueueSet(queues, deadletter, options);
+    return new QueueSet(queues, options);
   }
 
   static createMemoryQueue(name, options) {
@@ -581,14 +594,13 @@ class OspoCrawler {
     return new AttenuatedQueue(new TrackedQueue(queue, tracker, options), options);
   }
 
-  static createAmqp10Queue(manager, name, tracker, options, mode = { receive: 'receive', send: 'send' }) {
+  static createAmqp10Queue(manager, name, tracker, options) {
     const formatter = message => {
       // make sure the message/request object is copied to enable deferral scenarios (i.e., the request is modified
       // and then put back on the in-memory queue)
       return Request.adopt(Object.assign({}, message.body));
     };
     let queue = manager.createQueueClient(name, formatter, options);
-    queue.mode = mode;
     if (tracker) {
       queue = new TrackedQueue(queue, tracker, options);
     }
@@ -635,7 +647,7 @@ class OspoCrawler {
       return null;
     }
     const metrics = new RedisMetrics({ client: OspoCrawler.getRedisClient(options.logger) });
-    const queueNames = ['immediate', 'soon', 'normal', 'later', 'deadletter', 'events'];
+    const queueNames = ['immediate', 'soon', 'normal', 'later', 'events'];
     const operations = ['push', 'repush', 'done', 'abandon'];
     const queuesMetrics = {};
     const queueNamePrefix = options.queueName;
@@ -668,6 +680,8 @@ class OspoCrawler {
     return result.filter(line => { return line; }).map(line => { return line.toLowerCase(); });
   }
 }
+
+factoryLogger = OspoCrawler.createLogger(true);
 
 module.exports = OspoCrawler;
 

--- a/lib/storageDocStore.js
+++ b/lib/storageDocStore.js
@@ -34,7 +34,7 @@ class AzureStorageDocStore {
     const deferred = Q.defer();
     const blobName = this._getBlobNameFromDocument(document);
     const text = JSON.stringify(document);
-    const metadata = {
+    const blobMetadata = {
       version: document._metadata.version,
       etag: document._metadata.etag,
       type: document._metadata.type,
@@ -43,8 +43,10 @@ class AzureStorageDocStore {
       fetchedAt: document._metadata.fetchedAt,
       processedAt: document._metadata.processedAt
     };
-    this._collapseExtraMetadata(document._metadata, metadata);
-    const options = { metadata: metadata, contentSettings: { contentType: 'application/json' } };
+    if (document._metadata.extra) {
+      blobMetadata.extra = JSON.stringify(document._metadata.extra);
+    }
+    const options = { metadata: blobMetadata, contentSettings: { contentType: 'application/json' } };
     this.service.createBlockBlobFromText(this.name, blobName, text, options, (error, result, response) => {
       if (error) {
         return deferred.reject(error);
@@ -53,14 +55,6 @@ class AzureStorageDocStore {
       deferred.resolve(blobName);
     });
     return deferred.promise;
-  }
-
-  _collapseExtraMetadata(source, target) {
-    if (source.extra) {
-      Object.getOwnPropertyNames(source.extra).forEach(property => {
-        target[`extra_${property}`] = source.extra[property];
-      });
-    }
   }
 
   get(type, key) {
@@ -112,7 +106,13 @@ class AzureStorageDocStore {
             // metricsClient.trackError(err);
             callback(err);
           }
-          entries = entries.concat(result.entries.map(entry => entry.metadata));
+          entries = entries.concat(result.entries.map(entry => {
+            const blobMetadata = entry.metadata;
+            if (blobMetadata.extra) {
+              blobMetadata.extra = JSON.parse(blobMetadata.extra);
+            }
+            return blobMetadata;
+          }));
           callback(null);
         });
       },

--- a/lib/storageDocStore.js
+++ b/lib/storageDocStore.js
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+const async = require('async');
+const azure = require('azure-storage');
 const memoryCache = require('memory-cache');
 const Q = require('q');
 const URL = require('url');
@@ -41,6 +43,7 @@ class AzureStorageDocStore {
       fetchedAt: document._metadata.fetchedAt,
       processedAt: document._metadata.processedAt
     };
+    this._collapseExtraMetadata(document._metadata, metadata);
     const options = { metadata: metadata, contentSettings: { contentType: 'application/json' } };
     this.service.createBlockBlobFromText(this.name, blobName, text, options, (error, result, response) => {
       if (error) {
@@ -50,6 +53,14 @@ class AzureStorageDocStore {
       deferred.resolve(blobName);
     });
     return deferred.promise;
+  }
+
+  _collapseExtraMetadata(source, target) {
+    if (source.extra) {
+      Object.getOwnPropertyNames(source.extra).forEach(property => {
+        target[`extra_${property}`] = source.extra[property];
+      });
+    }
   }
 
   get(type, key) {
@@ -85,6 +96,38 @@ class AzureStorageDocStore {
     return deferred.promise;
   }
 
+  listDocuments(pattern) {
+    const blobPattern = this._getBlobPathFromUrn(null, pattern);
+    var entries = [];
+    var continuationToken = null;
+    const deferred = Q.defer();
+    async.doWhilst(
+      callback => {
+        var started = new Date().getTime();
+        this.service.listBlobsSegmentedWithPrefix(this.name, blobPattern, continuationToken, { include: azure.BlobUtilities.BlobListingDetails.METADATA, location: azure.StorageUtilities.LocationMode.PRIMARY_THEN_SECONDARY }, function (err, result, response) {
+          // metricsClient.trackDependency(url.parse(blobService.host.primaryHost).hostname, 'listBlobsSegmented', (new Date().getTime() - started), !err, "Http", { 'Container name': 'download', 'Continuation token present': result == null ? false : (result.continuationToken != null), 'Blob count': result == null ? 0 : result.entries.length });
+
+          if (err) {
+            continuationToken = null;
+            // metricsClient.trackError(err);
+            callback(err);
+          }
+          entries = entries.concat(result.entries.map(entry => entry.metadata));
+          callback(null);
+        });
+      },
+      function () {
+        return continuationToken !== null && entries.length < 10000;
+      },
+      function (err) {
+        if (err) {
+          return deferred.reject(err);
+        }
+        deferred.resolve(entries);
+      });
+    return deferred.promise;
+  }
+
   close() {
     return Q();
   }
@@ -105,13 +148,22 @@ class AzureStorageDocStore {
     return `${type}${parsed.path.toLowerCase()}.json`;
   }
 
+  _getBlobPathFromUrn(type, urn) {
+    if (!urn) {
+      return '';
+    }
+    if (!urn.startsWith('urn:')) {
+      return urn;
+    }
+    const pathed = urn.startsWith('urn:') ? urn.slice(4) : urn;
+    return pathed.replace(/:/g, '/').toLowerCase();
+  }
+
   _getBlobNameFromUrn(type, urn) {
     if (!urn.startsWith('urn:')) {
       return urn;
     }
-    let pathed = urn.startsWith('urn:') ? urn.slice(4) : urn;
-    pathed = pathed.replace(/:/g, '/').toLowerCase();
-    return `${pathed}.json`;
+    return `${this._getBlobPathFromUrn(type, urn)}.json`;
   }
 }
 

--- a/lib/urlToUrnMappingStore.js
+++ b/lib/urlToUrnMappingStore.js
@@ -40,6 +40,10 @@ class UrltoUrnMappingStore {
     });
   }
 
+  listDocuments(pattern) {
+    this.baseStore.listDocuments(pattern);
+  }
+
   close() {
     return this.baseStore.close();
   }

--- a/routes/deadletters.js
+++ b/routes/deadletters.js
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+const auth = require('../middleware/auth');
+const express = require('express');
+const expressJoi = require('express-joi');
+const Request = require('ghcrawler').request;
+const wrap = require('../middleware/promiseWrap');
+
+let crawlerService = null;
+const router = express.Router();
+
+router.get('/', auth.validate, wrap(function* (request, response) {
+  const requests = yield crawlerService.listDeadletters();
+  response.json(requests);
+}));
+
+// router.delete('/:queue', auth.validate, expressJoi.joiValidate(requestsSchema), wrap(function* (request, response) {
+//   const requests = yield crawlerService.getRequests(request.params.queue, parseInt(request.query.count, 10), true);
+//   if (!requests) {
+//     return response.sendStatus(404);
+//   }
+//   response.json(requests);
+// }));
+
+function setup(service) {
+  crawlerService = service;
+  return router;
+}
+module.exports = setup;


### PR DESCRIPTION
First cut at store/document based deadletters.  

* Works with Azure blob.  
* Inmemory implemented but not tested
* Mongo TBD

Other pending work
* getting the request bodies.  Currently we just list the dead letters based on the metadata.  Might look at just getting all the content as they are typically small.  not sure if we can do one API call and get back many blobs or if each is a round trip.
* Delete deadletters