### PR TITLE
Cache deadletter count

### DIFF
--- a/lib/storageDocStore.js
+++ b/lib/storageDocStore.js
@@ -140,7 +140,14 @@ class AzureStorageDocStore {
     return deferred.promise;
   }
 
-  count(pattern) {
+  count(pattern, force = false) {
+    const key = `${this.name}:count:${pattern || ''}`;
+    if (!force) {
+      const cachedCount = memoryCache.get(key);
+      if (cachedCount) {
+        return Q(cachedCount);
+      }
+    }
     const blobPattern = this._getBlobPathFromUrn(null, pattern);
     var entryCount = 0;
     var continuationToken = null;
@@ -163,6 +170,7 @@ class AzureStorageDocStore {
         if (err) {
           return deferred.reject(err);
         }
+        memoryCache.put(key, entryCount, 60000);
         deferred.resolve(entryCount);
       });
     return deferred.promise;


### PR DESCRIPTION
The key used in memory cache is `genecrawlerdev-deadletter:count:` on my local machine where the first part is coming from `CRAWLER_STORAGE_NAME`.