### PR TITLE
Add support for configuring AMQP socket options

### DIFF
--- a/lib/amqpQueue.js
+++ b/lib/amqpQueue.js
@@ -33,7 +33,7 @@ class AmqpQueue {
     const self = this;
     this.channel = Q
       .try(() => {
-        const socketOptions = self.options.socketOptions ? self.options.socketOptions : {};
+        const socketOptions = self.options.socketOptions || {};
         return amqp.connect(url, socketOptions);
       })
       .then(connection => {

--- a/lib/amqpQueue.js
+++ b/lib/amqpQueue.js
@@ -33,7 +33,8 @@ class AmqpQueue {
     const self = this;
     this.channel = Q
       .try(() => {
-        return amqp.connect(url);
+        const socketOptions = self.options.socketOptions ? self.options.socketOptions : {};
+        return amqp.connect(url, socketOptions);
       })
       .then(connection => {
         connection.on('error', self._reconnect.bind(self));
@@ -49,7 +50,7 @@ class AmqpQueue {
         return channel;
       },
       error => {
-        this.logger.warn(`Reconnection failed for ${this.queueName} using AMQP`);
+        this.logger.warn(`Reconnection failed for ${this.queueName} using AMQP`, error);
         return Q.delay(5000).then(self._reconnect.bind(self));
       });
     return this.channel;


### PR DESCRIPTION
This allows AMQP to be used with SSL certificates that aren't rooted to a CA that NodeJS trusts. For example, you can set the following to a trusted certificate chain:

```json
{
  "queueing": {
    "socketOptions": {
      "ca": "[PEM encoded cert bundle]"
    }
  }
}
```